### PR TITLE
Project Settings API read-only

### DIFF
--- a/source/includes/project_settings.md
+++ b/source/includes/project_settings.md
@@ -1,0 +1,62 @@
+# Project Settings
+
+## Get the project settings of a project
+
+```http
+GET /api/v2/projects/1/settings/ HTTP/1.1
+Accept: application/json
+Authorization: Token "YOUR SDE ACCESS TOKEN"
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "answers": [
+        "A21",
+        "A493"
+    ],
+    "survey_complete": true
+}
+```
+
+This endpoint returns data relevant to the profile for the current project
+
+**`GET /api/v2/projects/{project_id}/settings/`**
+
+---
+
+### Expand Filters
+
+```http
+GET /api/v2/projects/1/settings/?expand=answers HTTP/1.1
+Accept: application/json
+Authorization: Token "YOUR SDE ACCESS TOKEN"
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "answers": [
+        {
+            "id": "A21",
+            "cpe": "cpe:/question/answer",
+            "text": "",
+            "selected_by": []
+            "question": "Q100",
+        }
+    ],
+    "survey_complete": true
+}
+```
+
+See the [Expand Parameters](#expand-parameters) section for more details.
+
+Parameter | Description
+----------|------------
+answers   | answers in answers field are expanded to include id, cpe, text, selected_by
+---
+

--- a/source/includes/project_settings.md
+++ b/source/includes/project_settings.md
@@ -45,7 +45,7 @@ Content-Type: application/json
             "id": "A21",
             "cpe": "cpe:/question/answer",
             "text": "",
-            "selected_by": []
+            "selected_by": [],
             "question": "Q100",
         }
     ],

--- a/source/index.yml
+++ b/source/index.yml
@@ -27,6 +27,7 @@ includes:
  - phases
  - profiles
  - project_roles
+ - project_settings
  - projects
  - report_settings
  - server_info


### PR DESCRIPTION
This should be the complete Project Settings API read-only endpoint docs. Only thing we might be missing here is adding subsection & section, which Ehsan requested. I avoided putting it in as currently the endpoint doesn't return it and we need to figure out what to return for those. I don't think they have proper item_ids (especially as subsections are questions and so would have Q{num} item_ids so I'm not sure what we should use here. In-app we use slugs, but I think we've avoided that in the API. 