### PR TITLE
Add role to users field in multiple API endpoints.

### DIFF
--- a/source/includes/business_units.md
+++ b/source/includes/business_units.md
@@ -27,7 +27,11 @@ Content-Type: application/json
                 "email": "frank@sdelements.com",
                 "first_name": "Frank",
                 "last_name": "Testerton",
-                "is_active": true
+                "is_active": true,
+                "role": {
+                    "id": "UR4",
+                    "name": "Administrator"
+                },
             }],
             "groups": [{
                 "id": "G64",
@@ -100,7 +104,11 @@ Content-Type: application/json
         "email": "frank@sdelements.com",
         "first_name": "Frank",
         "last_name": "Testerton",
-        "is_active": true
+        "is_active": true,
+        "role": {
+            "id": "UR4",
+            "name": "Administrator"
+        },
     }],
     "groups": [{
         "id": "G64",
@@ -162,7 +170,11 @@ Content-Type: application/json
         "email": "test@example.com",
         "first_name": "Admin",
         "last_name": "Testerton",
-        "is_active": true
+        "is_active": true,
+        "role": {
+            "id": "UR4",
+            "name": "Administrator"
+        },
     }],
     "groups": [{
         "id": "G1"
@@ -228,7 +240,11 @@ Content-Type: application/json
         "id": 1,
         "first_name": "Admin",
         "last_name": "Testerton",
-        "is_active": true
+        "is_active": true,
+        "role": {
+            "id": "UR4",
+            "name": "Administrator"
+        },
     }],
     "groups": [{
         "id": "G1"

--- a/source/includes/groups.md
+++ b/source/includes/groups.md
@@ -86,7 +86,11 @@ Content-Type: application/json
             "last_name": "Testerton",
             "is_active": true,
             "id": 2,
-            "email": "frank@example.com"
+            "email": "frank@example.com",
+            "role": {
+                "id": "UR4",
+                "name": "Administrator"
+            },
         }],
         "groups": [{
             role: "User",
@@ -100,14 +104,22 @@ Content-Type: application/json
                 "last_name": "Testerton",
                 "is_active": true,
                 "id": 2,
-                "email": "frank@example.com"
+                "email": "frank@example.com",
+                "role": {
+                    "id": "UR4",
+                    "name": "Administrator"
+                },
             },
             {
                 "first_name": "Linda",
                 "last_name": "Graham",
                 "is_active": false,
                 "id": 3,
-                "email": "linda@example.com"
+                "email": "linda@example.com",
+                "role": {
+                    "id": "UR4",
+                    "name": "Administrator"
+                },
             },
 
         ]
@@ -198,7 +210,11 @@ Content-Type: application/json
         "last_name": "Testerton",
         "is_active": true,
         "id": 2,
-        "email": "frank@example.com"
+        "email": "frank@example.com",
+        "role": {
+            "id": "UR4",
+            "name": "Administrator"
+        },
     }],
     "groups": [{
         role: "User",
@@ -259,7 +275,11 @@ Content-Type: application/json
         "last_name": "Testerton",
         "is_active": true
         "id": 2,
-        "email": "frank@example.com"
+        "email": "frank@example.com",
+        "role": {
+            "id": "UR4",
+            "name": "Administrator"
+        },
     }],
     "groups": [{
         "role": "User"

--- a/source/includes/tasks.md
+++ b/source/includes/tasks.md
@@ -260,12 +260,17 @@ Content-Type: application/json
     "accepted": true,
     "ad_hoc": false,
     "artifact_proxy": "ABC-XYZ",
-    "assigned_to": [
-        {
-            "email": "admin@example.com",
-            "id": 3
-        }
-    ],
+    "assigned_to": [{
+        "first_name": "Admin",
+        "last_name": "Testerton",
+        "is_active": true,
+        "email": "admin@example.com",
+        "role":{
+            "id": "UR4",
+            "name": "Administrator"
+        },
+        "id": 1
+    }],
     "text": "Insecure forgotten password.",
     "id": "1-T2",
     "library_task_created": "2010-10-20T17:46:50Z",
@@ -324,8 +329,15 @@ Content-Type: application/json
     "artifact_proxy": "ABC-XYZ",
     "assigned_to": [
         {
+            "first_name": "User",
+            "last_name": "Testerton",
+            "is_active": true,
             "email": "user1@example.com",
-            "id": 3
+            "role":{
+                "id": "UR4",
+                "name": "Administrator"
+            },
+            "id": 1
         }
     ],
     "text": "Task Description",
@@ -400,9 +412,28 @@ Content-Type: application/json
     "artifact_proxy": "ABC-XYZ",
     "assigned_to": [
         {
-            "email": "user1@example.com",
-            "id": 3
+            "first_name": "User",
+            "last_name": "Testerton",
+            "is_active": true,
+            "email": "uesr1@example.com",
+            "role":{
+                "id": "UR4",
+                "name": "Administrator"
+            },
+            "id": 1
+        },
+        {
+            "first_name": "User",
+            "last_name": "Second",
+            "is_active": true,
+            "email": "user2@example.com",
+            "role":{
+                "id": "UR4",
+                "name": "Administrator"
+            },
+            "id": 2
         }
+
     ],
     "text": "Insecure forgotten password.",
     "id": "1-T2",


### PR DESCRIPTION
The inline 'users' field was made consistent across multiple endpoints in v4.1.
The API docs need to reflect this. 