### PR TITLE
Change user id to email for jobs endpoint

### DIFF
--- a/source/includes/changelog.md
+++ b/source/includes/changelog.md
@@ -3,6 +3,7 @@
 ## v4.5
 
 - Phases can be created, edited, or deleted.
+- Changed the value of user to email instead of id, since we filter users by email.
 
 ## v4.4
 

--- a/source/includes/jobs.md
+++ b/source/includes/jobs.md
@@ -15,7 +15,7 @@ Content-Type: application/json
 {
     "results": [{
         "id": 12,
-        "user": 1,
+        "user": "admin@example.com",
         "succeeded": true,
         "automatic": true,
         "ready": true,
@@ -91,7 +91,7 @@ Content-Type: application/json
 
 {
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": true,
     "automatic": true,
     "ready": true,
@@ -161,7 +161,7 @@ Content-Type: application/json
 
 {
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": true,
     "automatic": true,
     "ready": true,
@@ -238,7 +238,7 @@ Content-Type: application/json
 {
 
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": false,
     "automatic": false,
     "ready": false,
@@ -307,7 +307,7 @@ Content-Type: application/json
 {
     "results": [{
         "id": 12,
-        "user": 1,
+        "user": "admin@example.com",
         "succeeded": true,
         "automatic": true,
         "ready": true,
@@ -375,7 +375,7 @@ Content-Type: application/json
 
 {
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": true,
     "automatic": true,
     "ready": true,
@@ -437,7 +437,7 @@ Content-Type: application/json
 
 {
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": true,
     "automatic": true,
     "ready": true,
@@ -504,7 +504,7 @@ Content-Type: application/json
 
 {
     "id": 12,
-    "user": 1,
+    "user": "admin@example.com",
     "succeeded": false,
     "automatic": false,
     "ready": false,
@@ -597,7 +597,7 @@ Content-Type: application/json
         "ready": true,
         "result_message": "",
         "succeeded": true,
-        "user": 1
+        "user": "admin@example.com" 
     }]
 }
 ```
@@ -839,7 +839,7 @@ Content-Type: application/json
     "ready": true,
     "result_message": "",
     "succeeded": true,
-    "user": 1
+    "user": "admin@example.com" 
 }
 ```
 


### PR DESCRIPTION
Reason for this change

> user id is displayed in the results (say, "user": 106) whereas user email address (say, "user": "veyastar+o3@gmail.com") should be used as a parameter to filter the results. It is inconsistency!

Refs #SDE-3474

TODO:
- [x] Set milestone label in pull request (SDE version)
- [x] Updated changelog.md
- [x] Completed documentation for the new endpoint.
- [x] Feature has been merged into SDE develop.
