### PR TITLE
Remove Active Param from Phases

### DIFF
--- a/source/includes/phases.md
+++ b/source/includes/phases.md
@@ -132,7 +132,6 @@ name               | Yes      | The name of the phase.
 description        | No       | The description of the phase.
 tip                | No       | The tooltip for the phase.
 ordinal            | No       | The order of the phase.
-active             | No       | Whether or not the phase is active.
 retain             | No       | Determines whether this phase carries over statuses and notes by default.
 
 
@@ -180,7 +179,6 @@ name               | Yes      | The name of the phase.
 description        | Yes      | The description of the phase.
 tip                | Yes      | The tooltip for the phase.
 ordinal            | Yes      | The order of the phase.
-active             | No      | Whether or not the phase is active.
 retain             | Yes      | Determines whether this phase carries over statuses and notes by default.
 
 **`PATCH /api/v2/phases/{phase_id}/`**
@@ -191,7 +189,6 @@ name               | No      | The name of the phase.
 description        | No      | The description of the phase.
 tip                | No      | The tooltip for the phase.
 ordinal            | No      | The order of the phase.
-active             | No      | Whether or not the phase is active.
 retain             | No      | Determines whether this phase carries over statuses and notes by default.
 
 ### URL Parameters


### PR DESCRIPTION
    * Seeing as Active is currently read_only, it shouldn't appear in
      the params list as generally read_only fields aren't included

Refs #SDE-????

TODO:
- [X] Set milestone label in pull request (SDE version)
- [N/A] Updated changelog.md
- [X] Completed documentation for the new endpoint.
- [X] Feature has been merged into SDE develop.
