### PR TITLE
Fix incorrect attribute name in Project endpoint

### DIFF
--- a/source/includes/projects.md
+++ b/source/includes/projects.md
@@ -142,7 +142,7 @@ Content-Type: application/json
             "sync_with_alm",
             "edit_project_survey"
         ],
-        "incomplete_task_counts": {
+        "incomplete_tasks": {
             "high": 38,
             "medium": 60,
             "low": 11


### PR DESCRIPTION
- Should be incomplete_tasks instead of incomplete_task_counts

Refs #SDE-4241

TODO:
- [x] Set milestone label in pull request (SDE version)
- [x] Updated changelog.md
- [x] Completed documentation for the new endpoint.
- [x] Feature has been merged into SDE develop.
