### PR TITLE
Stub task status update for additional ALM info.

### DIFF
--- a/source/includes/tasks.md
+++ b/source/includes/tasks.md
@@ -542,6 +542,11 @@ Authorization: Token "YOUR SDE ACCESS TOKEN"
     "artifact_proxy": "ABC-XYZ",
     "assigned_to": ["user1@example.com", "user2@example.com"],
     "status": "TS1"
+    "status_context": {
+        "username": "user@externalsystem.com",
+        "modified_time": "2018-10-20T17:46:50Z",
+        "system": "Jira"
+    }
 }
 ```
 


### PR DESCRIPTION
We want to let people send additional data when updating a task status to indicate that the change happened in an other system.

TODO:
- [ ] Set milestone label in pull request (SDE version)
- [ ] Updated changelog.md
- [ ] Completed documentation for the new endpoint.
- [ ] Feature has been merged into SDE develop.
